### PR TITLE
Fix IllegalStateException caused by attempting to access already closed stream

### DIFF
--- a/src/main/java/Invokers/ApiClient.java
+++ b/src/main/java/Invokers/ApiClient.java
@@ -1062,11 +1062,12 @@ public class ApiClient {
 			responseCode = String.valueOf(response.code());
 			status = response.message();
 			String headerType = response.header("Content-Type");
-			if (headerType != null)
+			if (headerType != null) {
 				if (headerType.equals("application/xml") || headerType.equals("text/csv")
 						|| headerType.equals("application/pdf")) {
-					responseBody = response.body().string();
+					responseBody = response.toString();
 				}
+			}
 
 			T data = handleResponse(response, returnType);
 			

--- a/src/main/java/Invokers/ApiClient.java
+++ b/src/main/java/Invokers/ApiClient.java
@@ -1067,11 +1067,7 @@ public class ApiClient {
 						|| headerType.equals("application/pdf")) {
 					responseBody = response.body().string();
 				}
-			if (!(responseCode.equals("200"))) {
-				if (!responseCode.equals("201")) {
-					System.out.println(response.body().string());
-				}
-			}
+
 			T data = handleResponse(response, returnType);
 			
 			response.body().close();


### PR DESCRIPTION
In a scenario where we have `400`- `500` error codes, there is an attempt to print the response body and later on, the same source is used again to do the same thing, but this time the stream is already closed and it will fail `IllegalStateException("closed")` instead of the expected `ApiException`.

the line `response.body().string()` cannot be used twice.

https://github.com/CyberSource/cybersource-rest-client-java/issues/20 - looks like related issue.