### PR TITLE
Add new fields for deserializing to support PRA mandate

### DIFF
--- a/src/main/java/Model/PtsV2PaymentsRefundPost201ResponseProcessorInformation.java
+++ b/src/main/java/Model/PtsV2PaymentsRefundPost201ResponseProcessorInformation.java
@@ -41,6 +41,12 @@ public class PtsV2PaymentsRefundPost201ResponseProcessorInformation {
   @SerializedName("responseCode")
   private String responseCode = null;
 
+  @SerializedName("approvalCode")
+  private String approvalCode = null;
+
+  @SerializedName("networkTransactionId")
+  private String networkTransactionId = null;
+
   @SerializedName("achVerification")
   private PtsV2PaymentsPost201ResponseProcessorInformationAchVerification achVerification = null;
 
@@ -134,6 +140,31 @@ public class PtsV2PaymentsRefundPost201ResponseProcessorInformation {
     this.achVerification = achVerification;
   }
 
+  /**
+   * Get networkTransactionId
+   * @return networkTransactionId
+  **/
+  @ApiModelProperty(value = "")
+  public String getNetworkTransactionId() {
+    return networkTransactionId;
+  }
+
+  public void setNetworkTransactionId(String networkTransactionId) {
+    this.networkTransactionId = networkTransactionId;
+  }
+
+  /**
+   * Get approvalCode
+   * @return approvalCode
+  **/
+  @ApiModelProperty(value = "")
+  public String getApprovalCode() {
+    return approvalCode;
+  }
+
+  public void setApprovalCode(String approvalCode) {
+    this.approvalCode = approvalCode;
+  }
 
   @Override
   public boolean equals(java.lang.Object o) {


### PR DESCRIPTION
To comply with Purchase Return Authorization(PRA) mandate the merchant needs to store three new fields returned in the API response for credits authorization code, the credit authorization response, and the credit authorization’s network transaction ID.

As part of this added the three new fields to the PtsV2PaymentsRefundPost201ResponseProcessorInformation.java model.