### PR TITLE
Suggested fix for HttpClientFactory memory leak issue 

### DIFF
--- a/src/main/java/Invokers/HttpClientFactory.java
+++ b/src/main/java/Invokers/HttpClientFactory.java
@@ -94,7 +94,6 @@ public class HttpClientFactory {
                 additionalSettings.getCustomX509TrustManager(),
                 additionalSettings.getCustomHostnameVerifier(),
                 additionalSettings.getCustomRetryOnConnectionFailure(),
-                additionalSettings.getCustomNetworkEventListener(),
                 additionalSettings.getCustomProxy(),
                 additionalSettings.getCustomProxyAuthenticator()
         );

--- a/src/main/java/utilities/interceptors/RetryInterceptor.java
+++ b/src/main/java/utilities/interceptors/RetryInterceptor.java
@@ -1,6 +1,7 @@
 package utilities.interceptors;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import okhttp3.Interceptor;
 import okhttp3.Request;
@@ -51,4 +52,9 @@ public class RetryInterceptor implements Interceptor {
 		
 		return response;
 	}
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(requestMetrics);
+    }
 }

--- a/src/main/java/utilities/telemetry/RequestTransactionMetrics.java
+++ b/src/main/java/utilities/telemetry/RequestTransactionMetrics.java
@@ -2,6 +2,8 @@ package utilities.telemetry;
 
 import com.google.gson.Gson;
 
+import java.util.Objects;
+
 public class RequestTransactionMetrics {
 	private String responseCorrelationId;
 	private long roundaboutTime;
@@ -75,4 +77,9 @@ public class RequestTransactionMetrics {
 		this.setRetryCount(noOfRetries);
 		return this;
 	}
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(responseCorrelationId, roundaboutTime, computeTime, retryCount);
+    }
 }


### PR DESCRIPTION
Fixed by overriding hashCode() method in RequestTransactionMetrics.java & RetryInterceptor.java and excluding customNetworkEventListener from Invokers.HttpClientFactory#GetHashOfMerchantConfiguration() method in Object.hash() section as NetworkEventListener.callId & NetworkEventListener.callStartNanos are always unique per instance (see Invokers.ApiClient line 240) hence Invokers.HttpClientFactoryAdditionalSettings.customNetworkEventListener is unique too  so that GetHashOfMerchantConfiguration() always returns unique hash causing new entry of OkHttpClient in _httpClientInstances static ConcurrentHashmap  and possible OutOfMemoryError if ApiClient is always new (not singleton).